### PR TITLE
Change format of cli upgrade available message.

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1131,7 +1131,7 @@ func (s Service) outputLatestVersionMessage() {
 
 	showLatestVersion := os.Getenv("MINT_HIDE_LATEST_VERSION") == "" && os.Getenv("RWX_HIDE_LATEST_VERSION") == ""
 
-	if !showLatestVersion || !versions.NewVersionAvailable() {
+	if !showLatestVersion {
 		return
 	}
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1136,17 +1136,12 @@ func (s Service) outputLatestVersionMessage() {
 	}
 
 	w := s.Stderr
-	fmt.Fprintln(w, "========================================")
-	fmt.Fprintln(w, "A new version is available!")
-	fmt.Fprintf(w, "You are currently on version %s\n", versions.GetCliCurrentVersion())
-	fmt.Fprintf(w, "The latest version is %s\n", versions.GetCliLatestVersion())
+	fmt.Fprintf(w, "A new release of rwx is available: %s → %s\n", versions.GetCliCurrentVersion(), versions.GetCliLatestVersion())
 
 	if versions.InstalledWithHomebrew() {
-		fmt.Fprintln(w, "\nYou can update to the latest version with:")
-		fmt.Fprintln(w, "    brew upgrade rwx-cloud/tap/rwx")
+		fmt.Fprintln(w, "To upgrade, run: brew upgrade rwx-cloud/tap/rwx")
 	}
 
-	fmt.Fprintln(w, "========================================")
 	fmt.Fprintln(w)
 }
 


### PR DESCRIPTION
Update the message displayed when a new version is available to be simply:

```
A new release of rwx is available: 1.9.0 → 1.11.0
To upgrade, run: brew upgrade rwx-cloud/tap/rwx
```