### PR TITLE
Don't inject base specifications to files consisting entirely of embedded runs

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -916,6 +916,11 @@ func (s Service) getFilesForBaseResolveOrUpdate(entries []RwxDirectoryEntry, req
 			return false
 		}
 
+		// Skip if all tasks in this file are embedded runs
+		if doc.AllTasksAreEmbeddedRuns() {
+			return false
+		}
+
 		return true
 	})
 


### PR DESCRIPTION
If a run only calls other embedded runs, it doesn't need a base to begin with as no code will ever be executed on it.