### PR TITLE
Update output of mage to remove reference to Mint

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -37,7 +37,7 @@ func All(ctx context.Context) error {
 	return nil
 }
 
-// Build builds the Mint-CLI
+// Build builds the RWX CLI
 func Build(ctx context.Context) error {
 	args := []string{"./cmd/rwx"}
 


### PR DESCRIPTION
I noticed that the [readme version of the output ](https://github.com/rwx-cloud/cli/blob/main/CONTRIBUTING.md#development-setup) had been updated to remove reference to Mint, but when actually running `go run ./tools/mage -l`, it still used Mint terminology.

This PR updates the output to match what was in the documentation.